### PR TITLE
Turn off tree on KeyboardInterrupt in examples

### DIFF
--- a/examples/huecycle.py
+++ b/examples/huecycle.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from tree import RGBXmasTree
 from colorzero import Color, Hue
 
@@ -9,4 +11,5 @@ try:
     while True:
         tree.color += Hue(deg=1)
 except KeyboardInterrupt:
+    tree.off()
     tree.close()

--- a/examples/onebyone.py
+++ b/examples/onebyone.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from tree import RGBXmasTree
 from colorzero import Color
 
@@ -11,4 +13,5 @@ try:
             for pixel in tree:
                 pixel.color = color
 except KeyboardInterrupt:
+    tree.off()
     tree.close()

--- a/examples/randomsparkles.py
+++ b/examples/randomsparkles.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from tree import RGBXmasTree
 import random
 
@@ -14,4 +16,5 @@ try:
         pixel = random.choice(tree)
         pixel.color = random_color()
 except KeyboardInterrupt:
+    tree.off()
     tree.close()

--- a/examples/rgb.py
+++ b/examples/rgb.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from tree import RGBXmasTree
 from colorzero import Color
 from time import sleep
@@ -12,4 +14,5 @@ try:
             tree.color = color
             sleep(1)
 except KeyboardInterrupt:
+    tree.off()
     tree.close()


### PR DESCRIPTION
Turn off the tree on KeyboardInterrupt in examples and made the examples executable.